### PR TITLE
group admin able to see email removal, reveal_email option removal, and a minor grammar fix

### DIFF
--- a/app/Http/Controllers/Auth/LoginByEmailController.php
+++ b/app/Http/Controllers/Auth/LoginByEmailController.php
@@ -29,7 +29,7 @@ class LoginByEmailController extends Controller
         if ($user) {
             // send invitation email
             Mail::to($request->get('email'))->send(new LoginByEmail($user));
-            flash('Check your mailbox, we sent you a login link. It will expires in 30 minutes');
+            flash('Check your mailbox, we sent you a login link. It will expire in 30 minutes');
             return redirect('/');
         }
         else {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -61,7 +61,7 @@ class LoginController extends Controller
             if ($user) {
                 // send invitation email
                 Mail::to($user->email)->send(new LoginByEmail($user));
-                flash(__('Check your mailbox, we sent you a login link. It will expires in 30 minutes'));
+                flash(__('Check your mailbox, we sent you a login link. It will expire in 30 minutes'));
                 return redirect('/');
             }
             else {

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,5 +1,5 @@
 {
-    "Check your mailbox, we sent you a login link. It will expires in 30 minutes": "Check your mailbox, we sent you a login link. It will expires in 30 minutes",
+    "Check your mailbox, we sent you a login link. It will expire in 30 minutes": "Check your mailbox, we sent you a login link. It will expire in 30 minutes",
     "No user found, please create an account instead": "No user found, please create an account instead",
     "Incorrect password and\/or username": "Incorrect password and\/or username",
     "This user did not verify his\/her email so you cannot contact him\/her": "This user did not verify his\/her email so you cannot contact him\/her",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -1,5 +1,5 @@
 {
-    "Check your mailbox, we sent you a login link. It will expires in 30 minutes": "Check your mailbox, we sent you a login link. It will expires in 30 minutes",
+    "Check your mailbox, we sent you a login link. It will expire in 30 minutes": "Check your mailbox, we sent you a login link. It will expire in 30 minutes",
     "No user found, please create an account instead": "No user found, please create an account instead",
     "Incorrect password and\/or username": "Incorrect password and\/or username",
     "This user did not verify his\/her email so you cannot contact him\/her": "This user did not verify his\/her email so you cannot contact him\/her",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -1,5 +1,5 @@
 {
-    "Check your mailbox, we sent you a login link. It will expires in 30 minutes": "Vérifiez votre boite mail, nous vous avons envoyé un lien pour vous connecter. Il expirera dans 30 minutes",
+    "Check your mailbox, we sent you a login link. It will expire in 30 minutes": "Vérifiez votre boite mail, nous vous avons envoyé un lien pour vous connecter. Il expirera dans 30 minutes",
     "No user found, please create an account instead": "Pas d\\'utilisateur-trice trouvé(e), créez vous un compte ou vérifiez votre nom d'utilisateur-trice",
     "Incorrect password and\/or username": "Mot de passe ou nom d'utilisateur incorrect",
     "This user did not verify his\/her email so you cannot contact him\/her": "Cet utilisateur-trice doit vérifier son adresse email pour être contacté(e)",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -1,5 +1,5 @@
 {
-    "Check your mailbox, we sent you a login link. It will expires in 30 minutes": "Check your mailbox, we sent you a login link. It will expires in 30 minutes",
+    "Check your mailbox, we sent you a login link. It will expire in 30 minutes": "Check your mailbox, we sent you a login link. It will expire in 30 minutes",
     "No user found, please create an account instead": "No user found, please create an account instead",
     "Incorrect password and\/or username": "Incorrect password and\/or username",
     "This user did not verify his\/her email so you cannot contact him\/her": "This user did not verify his\/her email so you cannot contact him\/her",

--- a/resources/views/users/contact.blade.php
+++ b/resources/views/users/contact.blade.php
@@ -21,10 +21,6 @@
     {!! Form::textarea('body', null, ['class' => 'form-control', 'required']) !!}
   </div>
 
-  <div class="form-check">
-   <input type="checkbox" class="form-check-input" name="reveal_email" id="reveal_email" checked="checked">
-   <label class="form-check-label" for="reveal_email">{{__('Reveal my email to this user so we can communicate by email')}}</label>
- </div>
 
 
   <div class="form-group mt-4">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -30,11 +30,6 @@
         <th data-priority="4">{{ trans('messages.last_activity') }}</th>
         <th data-priority="2">{{ trans('messages.status') }}</th>
 
-        @can('manage-membership', $group)
-          <th data-priority="2">{{ trans('messages.notifications_interval') }}</th>
-          <th data-priority="1"></th>
-        @endcan
-
       </tr>
     </thead>
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -31,7 +31,6 @@
         <th data-priority="2">{{ trans('messages.status') }}</th>
 
         @can('manage-membership', $group)
-          <th data-priority="2">{{ trans('messages.email') }}</th>
           <th data-priority="2">{{ trans('messages.notifications_interval') }}</th>
           <th data-priority="1"></th>
         @endcan

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -30,6 +30,11 @@
         <th data-priority="4">{{ trans('messages.last_activity') }}</th>
         <th data-priority="2">{{ trans('messages.status') }}</th>
 
+        @can('manage-membership', $group)
+          <th data-priority="2">{{ trans('messages.notifications_interval') }}</th>
+          <th data-priority="1"></th>
+        @endcan
+
       </tr>
     </thead>
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -100,13 +100,6 @@
 
           @can('manage-membership', $group)
             <td>
-              {{$membership->user->email}}
-            </td>
-        <td data-order="{{ $membership->notification_interval }}">
-              {{minutesToInterval($membership->notification_interval)}}
-            </td>
-
-            <td>
               <a class="btn btn-primary btn-sm" href="{{action('GroupMembershipController@edit', [$group, $membership])}}">{{trans('messages.edit')}}</a>
             </td>
           @endcan


### PR DESCRIPTION
1) Removed ability for group administrators to view group member email addresses
This was in relation to https://github.com/agorakit/agorakit/issues/277

2) Removed reveal_email option on the contact form :
This seemed necessary for my use case or in general because, a user could contact another user and find out his email address when the email is revealed, as agorakit sends the email address with both users email addresses in the 'from' or 'to' field. Basically, you could find out any user's email address just by unchecking reveal email and waiting for agorakit to tell you via email.

3) grammar, 'will expires' to 'will expire' 
minor grammar fix

Not sure if you want to put these into the main agorakit, but I thought I'd offer.