### PR TITLE
Allow undelete user (#390)

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -13,8 +13,8 @@ class UserController extends Controller
      */
     public function index()
     {
-        //$users = \App\User::where('verified', 1)->get();
-        $users = \App\User::get();
+        // We need to bypass the Illuminate\Database\Eloquent\SoftDeletingScope
+        $users = \App\User::withTrashed()->get();
 
         return view('admin.user.index')->with('users', $users);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -407,4 +407,30 @@ class UserController extends Controller
             return redirect()->route('index');
         }
     }
+
+    /**
+     * Undelete the specified resource from storage.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function undelete(int $id)
+    {
+        $user = User::onlyTrashed()->findOrFail($id);
+
+        // Until an undelete permission is added
+        // allow delete granted user to undelete as well.
+        if (Gate::allows('delete', $user)) {
+
+            $user->restore();
+
+            flash(trans('messages.ressource_restored_successfully'));
+
+            return redirect()->route('users.show', $user);
+        } else {
+            abort(403);
+        }
+    }
+
 }

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -164,6 +164,7 @@ return array (
   'ressource_geocoded_successfully' => 'Ressource geocodiert erfolgreich',
   'ressource_not_created_successfully' => 'Ressource nicht erfolgreich erstellt',
   'ressource_not_updated_successfully' => 'Ressource nicht erfolgreich aktualisiert',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Mittel erfolgreich aktualisiert',
   'save' => 'Speichern',
   'search' => 'Durchsuchen',
@@ -176,6 +177,7 @@ return array (
   'show_all' => 'Alle einsehen',
   'show_history' => 'Verlauf anzeigen',
   'show_list' => 'Dateienliste anzeigen',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Es gibt ein Problem mit Ihrem Eintrag',
   'sort' => 'Art',
   'sort_by_created_at_asc' => 'Nach Erstellungsdatum aufsteigend sortieren',
@@ -199,6 +201,7 @@ return array (
   'this_will_allow_you_to_be_informed' => 'dies erlaubt es Ihnen, auf dem Laufenden zu bleiben und teilzunehmen',
   'title' => 'Titel',
   'unattend' => 'Unbeaufsichtigt',
+  'undelete' => 'Undelete', // TODO
   'unread_discussions' => 'Ungelesene Diskussionen',
   'upload' => 'Hochladen',
   'upload_files' => 'Daten hochladen',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -7,6 +7,7 @@ return array (
   'address_cannot_be_geocoded' => 'Your address cannot be geolocalized. Please use a simple format, like "number street, city"',
   'ressource_geocoded_successfully' => 'Resource geocoded successfully',
   'ressource_updated_successfully' => 'Resource updated successfully',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO Check English
   'invitation_sent_again' => 'Invitation sent again',
   'discussions' => 'Discussions',
   'not_allowed' => 'Not allowed',
@@ -53,6 +54,8 @@ return array (
   'last_activity' => 'Last activity',
   'admin' => 'Administrator',
   'email_verified' => 'Email verified',
+  'soft_deleted' => 'Deleted', // TODO Check English
+  'undelete' => 'Undelete', // TODO Check English
   'yes' => 'yes',
   'no' => 'no',
   'edit' => 'Edit',

--- a/resources/lang/eo/messages.php
+++ b/resources/lang/eo/messages.php
@@ -166,6 +166,7 @@ return array (
   'ressource_geocoded_successfully' => 'Resource geocoded successfully',
   'ressource_not_created_successfully' => 'Resource Not Created Successfully',
   'ressource_not_updated_successfully' => 'Resource Not Updated Successfully',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Resource updated successfully',
   'save' => 'Save',
   'search' => 'Search',
@@ -178,6 +179,7 @@ return array (
   'show_all' => 'Show all',
   'show_history' => 'Show history',
   'show_list' => 'Show file list',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Something is wrong with your submission',
   'sort' => 'Sort',
   'sort_by_created_at_asc' => 'Sort by creation date ascending',
@@ -201,6 +203,7 @@ return array (
   'this_will_allow_you_to_be_informed' => 'this will allow you to be informed and to participate',
   'title' => 'Title',
   'unattend' => 'Unattend',
+  'undelete' => 'Undelete', // TODO
   'unread_discussions' => 'Unread discussions',
   'upload' => 'Upload',
   'upload_files' => 'Upload Files',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -164,6 +164,7 @@ Introduzca una URL correcta comenzando por http:// y establezca un título para 
   'ressource_geocoded_successfully' => 'Recursos geocodificados correctamente',
   'ressource_not_created_successfully' => 'Recursos no creados con éxito',
   'ressource_not_updated_successfully' => 'Recurso no actualizado correctamente',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Recurso actualizado con éxito',
   'save' => 'Guardar',
   'search' => 'Buscar',
@@ -176,6 +177,7 @@ Introduzca una URL correcta comenzando por http:// y establezca un título para 
   'show_all' => 'Mostrar todo',
   'show_history' => 'Mostrar historial',
   'show_list' => 'Mostrar la lista de archivos',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Algo no funciona con su envío',
   'sort' => 'clase',
   'sort_by_created_at_asc' => 'Ordenar por fecha de creación ascendente',
@@ -199,6 +201,7 @@ Introduzca una URL correcta comenzando por http:// y establezca un título para 
   'this_will_allow_you_to_be_informed' => 'esto le permitirá estar informado y participar.',
   'title' => 'Título',
   'unattend' => 'Desatender',
+  'undelete' => 'Undelete', // TODO
   'unread_discussions' => 'Discusiones no leídas',
   'upload' => 'Subir',
   'upload_files' => 'Subir archivos',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -154,6 +154,7 @@ return array (
   'logout' => 'Déconnexion',
   'email_not_verified' => 'Votre adresse mail n\'est pas vérifiée, merci de la vérifier maintenant depuis votre boite email',
   'email_not_verified_send_again_verification' => 'Si vous n\'avez pas reçu le mail de confirmation cliquez ici pour en recevoir un autre',
+  'soft_deleted' => 'Supprimé', // TODO Check French
   'sort' => 'Trier',
   'sort_by_created_at_desc' => 'Le plus récent en premier',
   'sort_by_created_at_asc' => 'Le plus ancien en premier',
@@ -162,6 +163,7 @@ return array (
   'sort_by_filesize_asc' => 'Par taille croissante',
   'sort_by_filesize_desc' => 'Par taille décroissante',
   'notifications' => 'Notifications',
+  'undelete' => 'Restaurer', // TODO Check French
   'unattend' => 'Annuler ma participation',
   'visibility' => 'Visibilité
 ',
@@ -185,6 +187,7 @@ return array (
   'ressource_deleted_successfully' => 'Ce contenu a bien été supprimé',
   'you_have_verified_your_email' => 'Vous avez vérifié votre adresse email',
   'not_allowed' => 'Pas autorisé',
+  'ressource_restored_successfully' => 'Contenu restauré avec succès', // TODO Check French
   'ressource_updated_successfully' => 'Contenu mis à jour avec succès',
   'no_file_selected' => 'Aucun fichier sélectionné',
   'ressource_not_created_successfully' => 'La ressource n\'a pas été créée à cause d\'une erreur (vérififez votre formulaire)',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -176,6 +176,7 @@ return array (
   'thank_you' => 'Grazie per aver usato quest\'applicazione',
   'you_have_been_mentionned_by' => 'Sei stato menzionato da',
   'in_the_discussion' => 'nella discussione',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Risorsa aggiornate con successo',
   'ressource_deleted_successfully' => 'Risorsa eliminate con successo',
   'ressource_created_successfully' => 'Risorsa creata con successo',
@@ -237,9 +238,11 @@ return array (
   'remove_user_admin' => 'Revoca diritti admin',
   'reset_password_email_subject' => 'Resetta la tua password',
   'send_my_recover_email' => 'Manda la mia e-mail di recupero',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Qualcosa è andato storto con la tua immissione',
   'start' => 'Start',
   'stop' => 'Stop',
+  'undelete' => 'Undelete', // TODO
   'upload' => 'Carica',
   'user_invited' => 'Utente invitato',
   'user_made_member_successfuly' => 'Utente nominato membro con successo',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -164,6 +164,7 @@ return array (
   'ressource_geocoded_successfully' => 'Ressource geocoded succes',
   'ressource_not_created_successfully' => 'Ressource niet succesvol aangemaakt',
   'ressource_not_updated_successfully' => 'Ressource niet succesvol bijgewerkt',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Inhoud met succes bewerkt',
   'save' => 'Opslaan',
   'search' => 'Zoeken',
@@ -176,6 +177,7 @@ return array (
   'show_all' => 'Alles tonen',
   'show_history' => 'Geschiedenis van aanpassingen tonen',
   'show_list' => 'Tonen als lijst',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Er is iets mis met je inzending',
   'sort' => 'soort',
   'sort_by_created_at_asc' => 'Sorteer op aanmaakdatum oplopend',
@@ -199,6 +201,7 @@ return array (
   'this_will_allow_you_to_be_informed' => 'Op die manier blijft u op de hoogte van de activiteiten van deze groep, en kunt u deelnemen aan de discussies.',
   'title' => 'Titel',
   'unattend' => 'unattend',
+  'undelete' => 'Undelete', // TODO
   'unread_discussions' => 'Niet-gelezen discussies',
   'upload' => 'Uploaden',
   'upload_files' => 'Bestanden uploaden',

--- a/resources/lang/ru/messages.php
+++ b/resources/lang/ru/messages.php
@@ -166,6 +166,7 @@ return array (
   'ressource_geocoded_successfully' => 'Геокодирование ресурсов успешно выполнено',
   'ressource_not_created_successfully' => 'Не удалось создать ресурс',
   'ressource_not_updated_successfully' => 'Не удалось обновить ресурс',
+  'ressource_restored_successfully' => 'Resource undeleted successfully', // TODO
   'ressource_updated_successfully' => 'Ресурс успешно обновлен',
   'save' => 'Сохранить',
   'search' => 'Поиск',
@@ -178,6 +179,7 @@ return array (
   'show_all' => 'Показать всё',
   'show_history' => 'Показать историю',
   'show_list' => 'Показать список фалов',
+  'soft_deleted' => 'Deleted', // TODO
   'something_wrong' => 'Что-то не так с вашей заявкой',
   'sort' => 'Сортировка',
   'sort_by_created_at_asc' => 'Сортировка по дате создания по возрастанию',
@@ -201,6 +203,7 @@ return array (
   'this_will_allow_you_to_be_informed' => 'это позволит вам быть в курсе и участвовать',
   'title' => 'Название',
   'unattend' => 'Не принимать участия',
+  'undelete' => 'Undelete', // TODO
   'unread_discussions' => 'Непрочитанные обсуждения',
   'upload' => 'Загрузка',
   'upload_files' => 'Загрузка фалов',

--- a/resources/views/admin/user/index.blade.php
+++ b/resources/views/admin/user/index.blade.php
@@ -20,6 +20,7 @@
                     <th>{{ trans('messages.last_activity') }}</th>
                     <th data-priority="1" style="max-width: 50px; overflow: hidden;text-overflow: ellipsis;">{{ trans('messages.admin') }}</th>
                     <th data-priority="1" style="max-width: 50px; overflow: hidden;text-overflow: ellipsis;">{{ trans('messages.email_verified') }}</th>
+                    <th data-priority="1" style="max-width: 50px; overflow: hidden;text-overflow: ellipsis;">{{ trans('messages.soft_deleted') }}</th>
                     <th data-priority="1"></th>
                 </tr>
             </thead>
@@ -60,7 +61,19 @@
                         </td>
 
                         <td>
-                            <a class="btn btn-secondary" href="{{ route('users.edit', $user) }}">{{trans('messages.edit')}}</a>
+                            @if ($user->trashed() )
+                                {{trans('messages.yes')}}
+                            @else
+                                {{trans('messages.no')}}
+                            @endif
+                        </td>
+
+                        <td>
+                            @if ($user->trashed() )
+                                <a class="btn btn-info" href="{{ route('users.undelete', $user->id) }}">{{trans('messages.undelete')}}</a>
+                            @else
+                                <a class="btn btn-secondary" href="{{ route('users.edit', $user) }}">{{trans('messages.edit')}}</a>
+                            @endif
                         </td>
 
                     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -205,6 +205,8 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::get('users/{user}/delete', 'UserController@destroy')->name('users.delete.confirm');
     Route::delete('users/{user}/delete', 'UserController@destroy')->name('users.delete');
+    // Might rather need to implement a patch or post method
+    Route::get('users/{id}/undelete', 'UserController@undelete')->name('users.undelete');
 
     Route::get('users/{user}/contact', 'UserController@contactForm')->name('users.contactform');
     Route::post('users/{user}/contact', 'UserController@contact')->name('users.contact');


### PR DESCRIPTION
- Add an Deleted column to the admin's users list
- Edit button becomes Undelete for soft deleted users
- Translations got 3 new keys with French messages and English placeholders with TODO comments for checking or translating
- A get method is used (could be a better one)
- Undelete action is allowed on a per-delete permission base, until a proper permission be set
- Undelete action restores a user
- Restoring a user show their profile (could redirect to the list instead)
- No change were made to the annoying logout when a user is deleted (happened when using the GUI for testing purposes)