### PR TITLE
Feature : pinned group into navbar

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -337,6 +337,17 @@ class GroupController extends Controller
         });
         $group->setSetting('allowed_tags', $allowed_tags);
 
+        // handle navbar pinning
+        if (Auth::user()->isAdmin()) {
+            if ($request->has('pinned_navbar')) {
+                $group->setSetting('pinned_navbar', true);
+            } else {
+                if ($group->getSetting('pinned_navbar')) {
+                    $group->setSetting('pinned_navbar', false);
+                }
+            }
+        }
+
         // validation
         if ($group->isInvalid()) {
             // Oops.

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -236,6 +236,10 @@ class GroupController extends Controller
         });
         $group->setSetting('allowed_tags', $allowed_tags);
 
+        if ($request->user()->isAdmin()) {
+            $group->setSetting('pinned_navbar', $request->has('pinned_navbar'));
+        }
+
         // handle cover
         if ($request->hasFile('cover')) {
             Storage::disk('local')->makeDirectory('groups/' . $group->id);

--- a/resources/lang/en/group.php
+++ b/resources/lang/en/group.php
@@ -20,6 +20,7 @@ return array (
   'type' => 'Group type',
   'status' => 'Status',
   'pinned' => 'Pinned',
+  'navbar' => 'Display this group into the navigation bar. It won\'t be displayed into ":my_groups" anymore.',
   'archived' => 'Archived',
   'allowed_tags_title' => 'Manage tags on the content of this group',
   'allowed_tags_help' => 'If you want to limit the available tags to classify content in this group, enter the tags in the box below. If you want to allow any tag, leave the box empty.',

--- a/resources/lang/fr/group.php
+++ b/resources/lang/fr/group.php
@@ -20,6 +20,7 @@ return array (
   'type' => 'Type de groupe',
   'status' => 'Status',
   'pinned' => 'Épinglé',
+  'navbar' => 'Afficher ce groupe dans la barre de navigation. Il ne sera plus affiché dans l’onglet « :my_groups ».',
   'archived' => 'Archivé',
   'LLH:obsolete' => 
   array (

--- a/resources/views/groups/form.blade.php
+++ b/resources/views/groups/form.blade.php
@@ -48,3 +48,10 @@
         {!! Form::select('status', ['0' => trans('group.normal'), '10' => trans('group.pinned'), '-10' => trans('group.archived')], null, ['class' => 'form-control']) !!}
     </div>
 @endcan
+
+@if(Auth::user()->isAdmin())
+    <div class="form-group">
+        {!! Form::checkbox('pinned_navbar', 'yes', $group->getSetting('pinned_navbar', false)) !!}
+        {!! trans('group.navbar', ['my_groups' => trans('messages.my_groups')]) !!}
+    </div>
+@endif

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -10,6 +10,11 @@
             <span class="d-none d-md-inline">{{ setting('name') }}</span>
         </a>
 
+        @php
+            $groups = Auth::check() ? Auth::user()->groups()->orderBy('name')->get() : collect([]);
+            $pinned_groups = $groups->filter(fn($g) => $g->settings['pinned_navbar'] ?? false);
+            $overview_groups = $groups->filter(fn($g) => !in_array($g->id, $pinned_groups->pluck('id')->toArray()));
+        @endphp
 
         <!-- Single dropdown on mobile to browse groups -->
         @auth
@@ -20,7 +25,7 @@
                         {{ trans('messages.my_groups') }}
                     </a>
                     <div class="dropdown-menu">
-                        @foreach (Auth::user()->groups()->orderBy('name')->get() as $group)
+                        @foreach ($overview_groups as $group)
                             <a class="dropdown-item" href="{{ route('groups.show', $group) }}">{{ $group->name }}</a>
                         @endforeach
                     </div>
@@ -46,7 +51,7 @@
                                 {{ trans('messages.my_groups') }}
                             </a>
                             <div class="dropdown-menu">
-                                @foreach (Auth::user()->groups()->orderBy('name')->get() as $group)
+                                @foreach ($overview_groups as $group)
                                     <a class="dropdown-item"
                                         href="{{ route('groups.show', $group) }}">{{ $group->name }}</a>
                                 @endforeach
@@ -65,35 +70,62 @@
 
                     <ul class="dropdown-menu">
 
+                        @if (setting('show_overview_all_groups'))
                         <a class="dropdown-item" class="dropdown-item" href="{{ action('GroupController@index') }}">
                             {{ trans('messages.all_groups') }}
                         </a>
+                        @endif
 
+                        @if (setting('show_overview_discussions'))
                         <a class="dropdown-item " href="{{ action('DiscussionController@index') }}">
                             {{ trans('messages.discussions') }}
                         </a>
+                        @endif
 
+                        @if (setting('show_overview_agenda'))
                         <a class="dropdown-item" href="{{ action('ActionController@index') }}">
                             {{ trans('messages.agenda') }}
                         </a>
+                        @endif
+
                         @auth
+                            @if (setting('show_overview_tags'))
                             <a class="dropdown-item" href="{{ action('TagController@index') }}">
                                 @lang('Tags')
                             </a>
+                            @endif
 
+                            @if (setting('show_overview_map'))
                             <a class="dropdown-item" href="{{ action('MapController@index') }}">
                                 {{ trans('messages.map') }}
                             </a>
+                            @endif
+
+                            @if (setting('show_overview_files'))
                             <a class="dropdown-item" href="{{ action('FileController@index') }}">
                                 {{ trans('messages.files') }}
                             </a>
+                            @endif
 
+                            @if (setting('show_overview_users'))
                             <a class="dropdown-item" href="{{ action('UserController@index') }}">
                                 {{ trans('messages.users_list') }}
                             </a>
+                            @endif
                         @endauth
                     </ul>
                 </li>
+
+               <!-- pinned groups -->
+               @auth
+               @if(count($pinned_groups->toArray()))
+               @foreach($pinned_groups as $group)
+                   <li class="nav-item">
+                       <a href="{{ route('groups.show', $group) }}" class="nav-link">{{ $group->name }}</a>
+                   </li>
+               @endforeach
+               @endif
+                @endauth
 
                 <!-- help -->
                 @auth

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Group;
+use App\Membership;
+
 class UserTest extends Tests\BrowserKitTestCase
 {
     /******************* Why is it done this way ? ***************/
@@ -336,7 +339,32 @@ class UserTest extends Tests\BrowserKitTestCase
         $group = $this->getTestGroup();
 
         $this->actingAs($this->newbie())
-        ->get('groups/'.$group->id.'/actions/create')
+        ->get('groups/' . $group->id . '/actions/create')
         ->assertResponseStatus(403);
+    }
+
+    public function testUserCantPinGroupIntoNavbar()
+    {
+        $newbie = $this->newbie();
+        $group = Group::where('name', 'Test group of newbie')->firstOrFail();
+        $membership = Membership::firstOrNew(['user_id' => $newbie->id, 'group_id' => $group->id]);
+
+        $this->assertEquals($membership->membership, Membership::ADMIN);
+
+        $this->actingAs($newbie)
+            ->get('groups/' . $group->id . '/edit')
+            ->dontSeeText(trans('group.navbar', ['my_groups' => trans('messages.my_groups')]));
+    }
+
+    public function testAdminCanPinGroupIntoNavbar()
+    {
+        $this->actingAs($this->admin())
+            ->visit('groups/' . $this->getTestGroup()->id . '/edit')
+            ->seeText(trans('group.navbar', ['my_groups' => trans('messages.my_groups')]))
+            ->check('pinned_navbar')
+            ->press(trans('messages.save'));
+
+        $group = $this->getTestGroup(); // after set settings because they're updated
+        $this->assertTrue($group->settings['pinned_navbar']);
     }
 }


### PR DESCRIPTION
Hello :wave: 

As discussed in [the developers group](https://app.agorakit.org/groups/39/discussions/16757), there is the first feature I would like to append is to pin a group into the navigation bar.

To explain this need, I need to pin a group into the navigation bar (a group named "Documentation") to be easily accessed by other people, it will includes some medicine related documents for a platform at my work.

I think it would fit too for other collectives, like to pin a group to fit with an IRL event. 

Thank you. (:
