### PR TITLE
Correct base template for Insights

### DIFF
--- a/resources/views/admin/insights.blade.php
+++ b/resources/views/admin/insights.blade.php
@@ -1,4 +1,4 @@
-@extends('group')
+@extends('app')
 
 @section('content')
     @push('js')


### PR DESCRIPTION
 Fixes #462

Template was extending the wrong base, which expected `$group` data that didn't exist.