### PR TITLE
Update to PHP 8.1 and set platform in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,8 @@
   "keywords": ["groupware", "laravel"],
   "license": "AGPL",
   "type": "project",
-
-
   "require": {
-    "php": "^8",
+    "php": "^8.1",
     "barryvdh/laravel-translation-manager": "^0.5",
     "consoletvs/charts": "6.*",
     "cviebrock/eloquent-sluggable": "^8",
@@ -52,15 +50,15 @@
     "nunomaduro/collision": "^5",
     "phpunit/phpunit": "^9.0"
   },
-
-
-
   "config": {
     "optimize-autoloader": true,
     "preferred-install": "dist",
     "sort-packages": true,
     "allow-plugins": {
       "php-http/discovery": true
+    },
+    "platform": {
+      "php": "8.1"
     }
   },
   "extra": {


### PR DESCRIPTION
- Current requirement list will not build in PHP 8.0, it needs PHP 8.1.
- Add a `platform` Composer config locked to 8.1.

Without a `platform` defined, it will use whatever version you have locally. This can cause quite a bit of confusion with collaborators (I am using PHP 8.3, and it was trying to build a very different set of dependencies as a result).