### PR TITLE
Update Composer license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "agorakit/agorakit",
   "description": "Agorakit, groupware for citizen.",
   "keywords": ["groupware", "laravel"],
-  "license": "AGPL",
+  "license": "AGPL-3.0-only",
   "type": "project",
 
 


### PR DESCRIPTION
Validating the current composer.json give this warning:

`- License "AGPL" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.`

This corrects the license to a valid SPDX license identifier. You can alternatively use `AGPL-3.0-or-later` for forwards compatibility, but that can be changed at any time.