### PR TITLE
Fix Composer requirement issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "fakerphp/faker": "^1.19",
     "laravel/browser-kit-testing": "^6",
     "laravel/sail": "^1.23",
-    "laravel/tinker": "^2",
     "mmo/faker-images": "^0.6",
     "mockery/mockery": "^1",
     "nunomaduro/collision": "^5",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "misd/linkify": "^1.1",
     "mpratt/embera": "~2.0",
     "nicolaslopezj/searchable": "^1",
-    "rap2hpoutre/laravel-log-viewer": "1.7",
+    "rap2hpoutre/laravel-log-viewer": "^1.7",
     "spatie/icalendar-generator": "^2.1",
     "spatie/laravel-honeypot": "^3",
     "suin/php-rss-writer": "^1.6",


### PR DESCRIPTION
- Package `laravel/tinker` was redundantly in `require-dev`.
- Package `rap2hpoutre/laravel-log-viewer` was locked too tightly to particular version number which shouldn't be necessary assuming it adheres to semantic versioning.

These fix warnings when validating the composer.json file. They should not effect the outcome of the lock in #476.