### PR TITLE
Organize roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,88 +1,97 @@
-# Agorakit 2.0 (very soon)
-- Major bug fixed
-- Easy Docker based install
-- Polished UI also on mobile
-- Enhance usability and accessibility (need help)
-- More documentation (need help)
-- More locales (need help)
+# AgoraKit Roadmap
+_Collected goals for the project._
 
-# Agorakit 3.0 (Q4 2024 - Q1 2025)
-- Better integration (Embed, Ical, RSS) of all content including public calendar of events
-- Web push notifications + UI to manage those per group / per user
-- Bridge with collabora online / only office (WOPI) to allow online editing of docs
-- Webdav access for the files if the above does not work OR integrate nextcould or similar file storage backend for groups
-- Fediverse integration (minimal feature : allow Fediverse users to follow groups)
+Contribute an idea for discussion or propose a priority change by making a pull request!
 
-# Future of the project
-- More complete Fediverse integration if there is demand
-- Enhance the calendar features
-- Allow groups to federate cross servers cross applications
-- Your idea could be here :)
+Consider refining large projects into smaller ones before moving them higher in the list. Think about long term goals, then pick a good first iteration to prioritize that can be completed more easily. Momentum is more important than completeness. It isn't valuable until it ships.
 
+¹ _Proposed for NGI funding_
 
-# Planed work
-The following items have been proposed for NGI funding : 
+## Planned
+_Ordered list of prioritized projects. Everything in this section should have clear outcomes defined._
 
-## Documentation
-- Provide more complete end user documentation including visuals if needed.
-- Provide better group admin documentation.
-- The goal is to cover at least all the user facing features of Agorakit in the docs.
-
-## Simplify hosting
-Attracting new developers and server administrators requires a simple, standardized installation workflow.
+### Simplify hosting and development with Docker¹
+_Attracting new developers and server administrators requires a simple, standardized installation workflow._
 - Docker/OCI containers and (docker-)compose are a suitable approach for that:
-    - provide a production compose setup
-    - provide a development compose setup if needed (currently using laravel sail which works fine but seems overkill)
+    - Provide a production `compose setup`
+    - Provide a development `compose setup` (replacing Laravel Sail)
+- Document the process
+- Document alternatives (e.g. a separate Docker for sqlite)
 
-- document the process & alternatives (for example, I’d like to test if sqlite is an alternative for small instances, if it works, I’d provide a separate docker compose setup for this use case)
+### Improve documentation¹
+- End user documentation is nonexistent
+- Group admin documentation needs improvement
 
-## External members
-Allow people outside a closed group to contact the group. Either by web form, email or using a fediverse account (real inbox for groups).
-- Allow a group to publish public content (currently ical and rss are supported), provide a fediverse outbox at least for public content (public events including those in private groups
-are a good candidate)
-- This means extending users model & database to allow external users to be stored using their fediverse handle instead of email. This also means adding a new “external” role to
-group members. Finally it would be nice to have users authenticate using their fediverse account to reduce friction shall they want to join a group.
-- The way an external request (from someone outside a group) would be handled could be inspired by Basecamp external client feature. Basically, when an “external” person contacts a group, a new discussion is created, labeled as “from an external person”, the group can discuss as usual, and the whole discussion is sent to the external person as well.
+### Allow external members¹
+_Allow people outside a closed group to contact the group. Either by web form, email or using a fediverse account (real inbox for groups)._
+- Allow a group to publish public content (currently iCal and RSS are supported)
+    - Provide a fediverse outbox at least for public content (public events including those in private groups are a good candidate)
+- Extend users model & database
+    - Allow external users to be stored using their fediverse handle instead of email
+    - Add new “external” role to group members
+    - Nice to have: Users authenticate with fediverse account
+- External requests (from outside a group)
+    - When an “external” person contacts a group, a new discussion is created and labeled as “from an external person”
+    - Group can discuss as usual and the whole discussion is sent to the external person as well
+    - Example: Basecamp external client feature
 
-## Federation
-Allow groups to communicate with the Fediverse. Paves the way for a more complete Fediverse integration.
-- Search, test, choose, add an activitypub library
-- Outbox for groups containing public events
-- Auth & external contact from activitypub
+### Add initial Fediverse access¹
+_Allow groups to communicate with the Fediverse. First step toward further integration._
+- Select an ActivityPub library
+- Auth & external contact from ActivityPub
+- Allow Fediverse users to follow groups
+    - Outbox for groups containing public events
 
-## Mobile
-Agorakit is already a progressive web app that can be “installed” on mobile and desktop. Roughly 40% of users are on small screen, the UI need to be enhanced. Users expect to receive
-notifications in real-time with a mobile application like Agorakit.
-- Native mobile notifications using web push notifications + user interface to configure those
-(same way as emails notification preference UI).
-- Check all pages on mobile and fix readability / layout
+### Improve mobile experience¹
+_AgoraKit is a progressive web app (PWA) with 40% of users on small screen. Users expect to receive
+real-time notifications._
+- Native notifications using web push notifications + user interface to configure those per group and per user
+(same as email notification preferences UI)
+- Audit all pages on mobile for usability and identify the biggestst challenges for remediation
 
+### Improve accessibility
+- Audit for WCAG 2.0 AA status as a first-pass and remediate as needed
 
-# Additional ideas 
-Those would be good to implement at some point but are not yet prioritized. Let's collect here all the (wild or not) ideas.
+### Improve content integration
+- Support embed, iCal, RSS
 
-## Discussions
+### Improve localizaiton
+- Review current localization system for potential improvements & automation
+- Identify which new locales should be prioritized
+
+### Enhance calendar
+- Public calendar of events
+
+-----
+
+## Ideas 
+_Not yet prioritized. Order doesn't matter. Let's collect all the ideas (wild or not) here._
+
+### Discussions
 - Store attachments in a separate directory in files, called "discussions" for example
 - Fix the "scroll to latest unread item" functionality on discussion list
-- Provide a nice navigation for longer discussions (check Flarum & Discourse implementations)... but do it in a simple way.
-- Improve image display in text content : https://feedback.agorakit.org/posts/10/improve-image-display
-    "When you upload an image, it is displayed in the same form as a file of another type (pdf or other).
-    Would it be possible (when they are jpg, gif, png) to have a more "nice" display ;0) --> namely the image which is displayed directly.
-    And this with the possibility of enlargement, with a lightbox effect?"
+- Provide a nice navigation for longer discussions (ex: Flarum & Discourse) in a simple way
+- Add [inline image display](https://feedback.agorakit.org/posts/10/improve-image-display)
 
-## Files
-- Provide a Webdav access to files, per group. Also for connected users, show all their groups, each in a separate folder when using webdav.
-- Provide a WOPI interface to allow integration with online office tools (collabora, onlyoffice and office seems to use this not very known standard)
-- Allow to drop a file anywhere on the window browser to upload
-- Preview more file types on file embed and show view.
+### Files
+- Provide Webdav access to files per group.
+    - For connected users, show all their groups, each in a separate folder when using webdav
+- Provide WOPI interface to allow integration with online office tools 
+    - Collabora Online, OnlyOffice, and Office seems to use this not very known standard
+- Allow drag-and-drop file upload
+- Preview more file types on file embed and show view
 
-## Notifications
-- More notifications with UI to manage if you get one and on which channel. For example "get an email / webpush when an event is created in group xyz". "When someone joins / leaves / etc. the group xyz". 
-- Per group, per user. 
-- Allow those notifications to be grouped in the summary email as well. 
-- Provide a nice UI with nice defaults and simple checkboxes. 
-- Additional notifications types for group admins.
+### Notifications
+- Add notifications
+    - Enable/disable per channel
+    - Per group, per user
+    - Nice defaults and simple checkboxes
+    - Examples:
+        - "get an email / webpush when an event is created in group xyz"
+        - "When someone joins / leaves / etc. the group xyz"
+- Allow notifications to be grouped in the summary email
+- Add notification types for group admins
 
-## Installation
-Use Phing based build to provide an archive users just have to upload in order to install Agorakit on shared hosting.
+### Simple install
+- Use Phing-based build to provide a file archive users can upload directly to install AgoraKit on shared hosting
 


### PR DESCRIPTION
I attempted to faithfully recreate the roadmap in a unified format:

* Organize the existing roadmap into 2 clear sections (Planned vs Ideas)
* Order the Planned section by priority (as best I could deduce from listed goals & our conversation)
* Unify formatting, punctuation, etc
* Remove dates (no one is paying us to hit deadlines 🙃)
* Combine related items (so there is only 1 list) and mark NGI-related ones (rather than separating them)
* Edit the text to be as concise & clear as possible

I attempted to simply organize what was already there. I did not intend to delete anything or radically change priority. If I made any errors due to misunderstanding, please correct them!

My next step will be to propose any changes, additions, or scope clarification in followup PRs. This one is just to make it clear enough I can do that confidently.