### PR TITLE
Create security poilicy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+We currently only support the latest version of Agorakit with security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.9.x   | :white_check_mark: |
+| < 1.9   | :x:                |
+
+## Reporting a Vulnerability
+
+Please use the GitHub "Security" tab to report vulnerabilities.
+
+Critical & High vulnerabilities will be addressed within 30 days.
+
+We will disclose vulnerability reports 90 days after they are remediated. This is to allow open source installations adequate time to update.
+
+We are unable to offer security bug bounties at this time.


### PR DESCRIPTION
Create an official policy for how to handle security reports.

I've also enabled the security reporting option for the repo.

This enables the "Security policy" recommendation under the repo's Security tab.