### PR TITLE
Create bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**How to reproduce**
+1. Go to '...'
+2. Click on '....'
+3. See error: "Message here"
+
+**Expected behavior**
+What you _expected_ to happen.
+
+**Screenshots**
+We greatly appreciate screenshots if possible!
+
+**Device (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Anything else you can tell us?


### PR DESCRIPTION
Add a template to help prompt folks to provide enough information in their bug reports. They can of course still delete / skip the template content.