### PR TITLE
Update .editorconfig whitespace handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,5 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Prompt editors to trim trailing whitespace & enforce a final newline at end of files.