### PR TITLE
Delete phpspec.yml

### DIFF
--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,5 +1,0 @@
-suites:
-    main:
-        namespace: App
-        psr4_prefix: App
-        src_path: app


### PR DESCRIPTION
It appears PHPSpec was part of the initial commit long ago but is no longer in the repo. I'm not opposed to using it again one day, but the file shouldn't be here if it's not actively being used.