### PR TITLE
Remove custom text from license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,9 +1,3 @@
-    Agorakit, mobilize crowds efficiently
-    Copyright (C) 2015  Philippe Jadin
-
-    www.philippejadin.be - www.123piano.com - www.agorakit.org
-
-
     GNU AFFERO GENERAL PUBLIC LICENSE
        Version 3, 19 November 2007
 


### PR DESCRIPTION
This information can be elsewhere, but not in the license file — it's technically not allowed, and it's why GitHub doesn't properly detect the repo as being AGPL-3.0 and says "View license" in the sidebar instead.