### PR TITLE
Fix error in comment controller uploaded file variable name

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -43,7 +43,7 @@ class CommentController extends Controller
             $file->user()->associate(Auth::user());
 
             // store the file itself on disk
-            $file->addToStorage($uploaded_file);
+            $file->addToStorage($request->file('file'));
 
             // add an f:xx to the comment so it is shown on display
             $comment->body = $comment->body . '<p>f:' . $file->id . '</p>';
@@ -105,7 +105,7 @@ class CommentController extends Controller
             $file->user()->associate(Auth::user());
 
             // store the file itself on disk
-            $file->addToStorage($uploaded_file);
+            $file->addToStorage($request->file('file'));
 
             // add an f:xx to the comment so it is shown on display
             $comment->body = $comment->body . '<p>f:' . $file->id . '</p>';


### PR DESCRIPTION
Since #534 an undefined $uploaded_file was in the comment controller. It has been renamed to the correct file from the request getter.