### PR TITLE
Update phpunit config for v11

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="bootstrap/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">app/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
@@ -29,6 +30,5 @@
         <env name="TESTING_DB_USERNAME" value="root"/>
         <env name="TESTING_DB_PASSWORD" value="root"/>
         <env name="MAIL_DRIVER" value="log"/>
-
     </php>
 </phpunit>


### PR DESCRIPTION
Fixes deprecation warning when running PHPUnit, and turns on verbose reporting for problems.