### PR TITLE
Fix sqlite migrate refresh

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -212,15 +212,16 @@ class GroupController extends Controller
             }
         }
 
+        $group->user()->associate(Auth::user());
         if ($group->isInvalid()) {
             // Oops.
             return redirect()->route('groups.create')
                 ->withErrors($group->getErrors())
                 ->withInput();
         }
-        $group->save();
 
-        $group->user()->associate(Auth::user());
+
+        $group->save();
 
         if ($request->get('tags')) {
             $group->tag($request->get('tags'));

--- a/database/migrations/2018_08_28_170800_add_username_to_users.php
+++ b/database/migrations/2018_08_28_170800_add_username_to_users.php
@@ -25,6 +25,7 @@ class AddUsernameToUsers extends Migration
     public function down()
     {
         Schema::table('users', function ($table) {
+            $table->dropIndex('users_username_unique');
             $table->dropColumn('username');
         });
     }

--- a/database/migrations/2018_11_19_200041_add_slug_to_groups.php
+++ b/database/migrations/2018_11_19_200041_add_slug_to_groups.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
 
 class AddSlugToGroups extends Migration
 {
@@ -12,7 +13,7 @@ class AddSlugToGroups extends Migration
      */
     public function up()
     {
-        Schema::table('groups', function ($table) {
+        Schema::table('groups', function (Blueprint $table) {
             $table->string('slug');
         });
     }
@@ -24,7 +25,8 @@ class AddSlugToGroups extends Migration
      */
     public function down()
     {
-        Schema::table('groups', function ($table) {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropIndex('groups_slug_unique');
             $table->dropColumn('slug');
         });
     }

--- a/database/migrations/2020_05_08_084059_add_status_to_discussions.php
+++ b/database/migrations/2020_05_08_084059_add_status_to_discussions.php
@@ -28,6 +28,7 @@ class AddStatusToDiscussions extends Migration
     public function down()
     {
         Schema::table('discussions', function (Blueprint $table) {
+            $table->dropIndex(['status']);
             $table->dropColumn('status');
         });
     }

--- a/database/migrations/2020_05_08_112228_add_status_to_files.php
+++ b/database/migrations/2020_05_08_112228_add_status_to_files.php
@@ -28,6 +28,7 @@ class AddStatusToFiles extends Migration
     public function down()
     {
         Schema::table('files', function (Blueprint $table) {
+            $table->dropIndex(['status']);
             $table->dropColumn('status');
         });
     }

--- a/database/migrations/2020_05_08_123537_add_status_to_groups.php
+++ b/database/migrations/2020_05_08_123537_add_status_to_groups.php
@@ -28,6 +28,7 @@ class AddStatusToGroups extends Migration
     public function down()
     {
         Schema::table('groups', function (Blueprint $table) {
+            $table->dropIndex(['status']);
             $table->dropColumn('status');
         });
     }

--- a/database/migrations/2023_10_02_153943_add_visibility_to_actions.php
+++ b/database/migrations/2023_10_02_153943_add_visibility_to_actions.php
@@ -28,6 +28,7 @@ class AddVisibilityToActions extends Migration
     public function down()
     {
         Schema::table('actions', function (Blueprint $table) {
+            $table->dropIndex(['visibility']);
             $table->dropColumn('visibility');
         });
     }

--- a/database/migrations/2025_03_01_205539_update_more_nullable_fields.php
+++ b/database/migrations/2025_03_01_205539_update_more_nullable_fields.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        /*  Schema::table('users', function (Blueprint $table) {
+            $table->text('body')->nullable()->default(null)->change();
+            $table->text('preferences')->nullable()->default(null)->change();
+            $table->text('address')->nullable()->default(null)->change();
+            $table->float('latitude', 10, 7)->nullable()->default(null)->change();
+            $table->float('longitude', 10, 7)->nullable()->default(null)->change();
+        });
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('locale')->nullable()->default(null)->change();
+        });*/
+
+        Schema::table('groups', function (Blueprint $table) {
+            $table->string('cover')->nullable()->default(null)->change();
+            $table->string('color')->nullable()->default(null)->change();
+            $table->text('settings')->nullable()->default(null)->change();
+            $table->text('address')->nullable()->default(null)->change();
+            $table->float('latitude', 10, 7)->nullable()->default(null)->change();
+            $table->float('longitude', 10, 7)->nullable()->default(null)->change();
+        });
+
+        Schema::table(
+            'membership',
+            function (Blueprint $table) {
+                $table->text('config')->nullable()->default(null)->change();
+                $table->timestamp('notified_at')->nullable()->default(null)->change();
+            }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->string('cover')->nullable(false)->default(null)->change();
+            $table->string('color')->nullable(false)->default(null)->change();
+            $table->text('settings')->nullable(false)->default(null)->change();
+            $table->text('address')->nullable(false)->default(null)->change();
+            $table->float('latitude', 10, 7)->nullable(false)->default(null)->change();
+            $table->float('longitude', 10, 7)->nullable(false)->default(null)->change();
+        });
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('locale')->nullable(false)->default(null)->change();
+        });
+
+        Schema::table(
+            'membership',
+            function (Blueprint $table) {
+                $table->text('config')->nullable(false)->default(null)->change();
+                $table->timestamp('notified_at')->nullable(false)->default(null)->change();
+            }
+        );
+    }
+};

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -10,7 +10,7 @@ class FileUploadTest extends Tests\BrowserKitTestCase
     */
     public function testSetupItAll()
     {
-        Artisan::call('migrate:refresh');
+        Artisan::call('migrate:fresh');
 
         $this->visit('/')
             ->see('Agorakit');
@@ -56,11 +56,11 @@ class FileUploadTest extends Tests\BrowserKitTestCase
         $group = App\Group::where('name', 'File upload test group')->firstOrFail();
 
         $this->actingAs($user)
-          ->visit('/groups/' . $group->id . '/files/createfolder')
-          ->see('Create a folder')
-          ->type('Test folder', 'name')
-          ->press('Create')
-          ->see('Test folder');
+            ->visit('/groups/' . $group->id . '/files/createfolder')
+            ->see('Create a folder')
+            ->type('Test folder', 'name')
+            ->press('Create')
+            ->see('Test folder');
     }
 
     public function testFileUpload()
@@ -72,11 +72,11 @@ class FileUploadTest extends Tests\BrowserKitTestCase
         $pathname = stream_get_meta_data($file->tempFile)['uri'];
 
         $this->actingAs($user)
-          ->visit('/groups/' . $group->id . '/files/create')
-          ->see('Upload file')
-          ->attach($pathname, 'file')
-          ->press('Create')
-          ->see('Resource created successfully')
-          ->see('Upload File');
+            ->visit('/groups/' . $group->id . '/files/create')
+            ->see('Upload file')
+            ->attach($pathname, 'file')
+            ->press('Create')
+            ->see('Resource created successfully')
+            ->see('Upload File');
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -55,7 +55,7 @@ class UserTest extends Tests\BrowserKitTestCase
     */
     public function testSetupItAll()
     {
-        Artisan::call('migrate:refresh');
+        Artisan::call('migrate:fresh');
 
         $this->visit('/')
             ->see('Agorakit');
@@ -339,8 +339,8 @@ class UserTest extends Tests\BrowserKitTestCase
         $group = $this->getTestGroup();
 
         $this->actingAs($this->newbie())
-        ->get('groups/' . $group->id . '/actions/create')
-        ->assertResponseStatus(403);
+            ->get('groups/' . $group->id . '/actions/create')
+            ->assertResponseStatus(403);
     }
 
 


### PR DESCRIPTION
This is a work in progress attempt to resolve #550 

As far as I can tell, there is still work to do on :

- raw sql queries in the send notification code that seems to be too mysql/mariadb specific
- migrations ->down() that mostly don't work on sqlite