### PR TITLE
Update shell scripts and move to /bin

### DIFF
--- a/bin/translate.sh
+++ b/bin/translate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+printf "Finding new strings in code...\n"
+php artisan localize
+
+printf "Syncing translations with translation.io...\n"
+php artisan translation:sync
+
+printf "Finished translation sync.\n"

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -1,18 +1,25 @@
+#!/usr/bin/env bash
+
+printf "Suspending app...\n"
 php artisan down --refresh=30 --render="errors::503"
 
+printf "Updating code...\n"
 git checkout main
 git pull
 
+printf "Refreshing dependencies...\n"
 composer install --ignore-platform-reqs
 
+printf "Updating database...\n"
 php artisan migrate --force
 
-
-
+printf "Clearing cache...\n"
 php artisan view:cache
 php artisan config:cache
 php artisan event:cache
 php artisan route:clear
 
-
+printf "Restoring app...\n"
 php artisan up
+
+printf "Finished update.\n"

--- a/translate
+++ b/translate
@@ -1,4 +1,0 @@
-echo Step 1 : find new strings in code
-php artisan localize
-echo Step 2 : sync translations with translation.io
-php artisan translation:sync


### PR DESCRIPTION
I thought better of trying to cram app-related scripts into Composer, which should probably be reserved for tooling. Instead, let's use a standard `bin` folder, a `.sh` prefix for clarity, and use a shebang with nice output that double as docs. 

Closes #570
Closes #571