### PR TITLE
show group location only to group members (privacy)

### DIFF
--- a/app/Traits/HasLocation.php
+++ b/app/Traits/HasLocation.php
@@ -46,6 +46,18 @@ trait HasLocation
 
 
     /**
+     * Return true if this model has at least one location field filled
+     */
+    public function hasLocation()
+    {
+        foreach ($this->location as $value) {
+            if (strlen($value) > 0) return true;
+        }
+        return false;
+    }
+
+
+    /**
      * Geocode the model using $this->getLocationData() data and sets $this->latitude and $this->longitude
      */
     function geocode()
@@ -57,12 +69,11 @@ trait HasLocation
         }
         $geoline = [];
         foreach (get_object_vars($this->location) as $key => $val) {
-            if ($key == 'name') {}
-            else if ($key == 'county' && $this->location->country) {
-              $geoline[] = $this->parse_county($val, $this->location->country);
-            }
-            else {
-              $geoline[] = $val;
+            if ($key == 'name') {
+            } else if ($key == 'county' && $this->location->country) {
+                $geoline[] = $this->parse_county($val, $this->location->country);
+            } else {
+                $geoline[] = $val;
             }
         }
         // Calling geocode function - even more abstracted than geocoder php.
@@ -82,35 +93,34 @@ trait HasLocation
      */
     function parse_county($county, $country)
     {
-     if (!is_numeric($county)) {
-       return $county;
-     }
-     if (strtolower($country) <> 'fr' && strtolower($country) <> "france") {
-       return $county;
-     }
-     if (strlen($county) < 4) { // French departement 2 or 3-digits code
-       return "FR-" . $county;  // ISO 3166-2
-     }
-     return $county;
-  }
+        if (!is_numeric($county)) {
+            return $county;
+        }
+        if (strtolower($country) <> 'fr' && strtolower($country) <> "france") {
+            return $county;
+        }
+        if (strlen($county) < 4) { // French departement 2 or 3-digits code
+            return "FR-" . $county;  // ISO 3166-2
+        }
+        return $county;
+    }
 
     /**
      * We need a function to display a location as a string.
      * Knowing that it is stored as a JSON structure in the database,
      * with keys: name, street, city, county, country.
      */
-    public function location_display($format="short")
+    public function location_display($format = "short")
     {
         $parts = [];
-        foreach($this->location_keys as $attr) {
-           if ($this->location->$attr) {
-            if ($format == "short" && $attr == 'street') {
-              $parts[] = substr($this->location->$attr, 0, 30);
-              }
-            else {
-              $parts[] = $this->location->$attr;
+        foreach ($this->location_keys as $attr) {
+            if ($this->location->$attr) {
+                if ($format == "short" && $attr == 'street') {
+                    $parts[] = substr($this->location->$attr, 0, 30);
+                } else {
+                    $parts[] = $this->location->$attr;
+                }
             }
-          }
         }
         return implode(", ", $parts);
     }

--- a/resources/views/groups/group.blade.php
+++ b/resources/views/groups/group.blade.php
@@ -60,34 +60,40 @@
                     </div>
                 @endif
 
-                <p>Location: {{ $group->location_display() }}</p>
-
+                @auth
+                    @if (Auth::user()->isMemberOf($group))
+                        @if ($group->hasLocation())
+                            <div class="text-body-secondary mt-3"><i class="fa fa-map-marker"></i> {{ $group->location_display() }}</div>
+                        @endif
+                    @endif
+                @endauth
+                
             </div>
         </div>
 
-        <div class="card-footer text-body-secondary small">
+        @auth
+            <div class="card-footer text-body-secondary small">
+                <div class="d-flex justify-content-between">
+                    <div>
+                        <i class="far fa-comments me-1"></i>
+                        <span> {{ $group->discussions->count() }}</span>
+                    </div>
 
-            <div class="d-flex justify-content-between">
-                <div>
-                    <i class="far fa-comments me-1"></i>
-                    <span> {{ $group->discussions->count() }}</span>
-                </div>
+                    <div>
+                        <i class="far fa-calendar-alt me-1"></i>
+                        <span>{{ $group->actions->count() }}</span>
+                    </div>
+                    <div>
+                        <i class="fas fa-users me-1"></i>
+                        <span>{{ $group->users->count() }}</span>
+                    </div>
 
-                <div>
-                    <i class="far fa-calendar-alt me-1"></i>
-                    <span>{{ $group->actions->count() }}</span>
-                </div>
-                <div>
-                    <i class="fas fa-users me-1"></i>
-                    <span>{{ $group->users->count() }}</span>
-                </div>
-
-                <div>
-                    <i class="far fa-lightbulb me-1"></i>
-                    <span>{{ $group->updated_at->diffForHumans() }}</span>
+                    <div>
+                        <i class="far fa-lightbulb me-1"></i>
+                        <span>{{ $group->updated_at->diffForHumans() }}</span>
+                    </div>
                 </div>
             </div>
-
-        </div>
+        @endauth
     </div>
 </div>


### PR DESCRIPTION
Group location should not be shown outside group members by default imho. This reverse the changes introduced in the group  template in #552 

It also  introduces an hasLocation() function that can be used in views to determine if a model has location data or not.